### PR TITLE
Fro->fro in documentation

### DIFF
--- a/doc/funcref.rst
+++ b/doc/funcref.rst
@@ -112,7 +112,7 @@ Nonlinear
     two-argument version ``norm(x,p)`` is supported as follows:
 
     -  ‡ For vectors, all values :math:`p\geq 1` are accepted.
-    -  For matrices, ``p`` must be ``1``, ``2``, ``Inf``, or ``'Fro'``.
+    -  For matrices, ``p`` must be ``1``, ``2``, ``Inf``, or ``'fro'``.
 
 ``polyval``
     polynomial evaluation. ``polyval(p,x)``, where ``p`` is a vector of


### PR DESCRIPTION
Using 'Fro' throws the following error: "Second argument must be a real number between 1 and Inf, or 'fro'."