### PR TITLE
Fix typo in documentation

### DIFF
--- a/doc/funcref.rst
+++ b/doc/funcref.rst
@@ -112,7 +112,7 @@ Nonlinear
     two-argument version ``norm(x,p)`` is supported as follows:
 
     -  ‡ For vectors, all values :math:`p\geq 1` are accepted.
-    -  For matrices, ``p`` must be ``1``, ``2``, ``Inf``, or ``'Fro'``.
+    -  For matrices, ``p`` must be ``1``, ``2``, ``Inf``, or ``'fro'``.
 
 ``polyval``
     polynomial evaluation. ``polyval(p,x)``, where ``p`` is a vector of


### PR DESCRIPTION
This is at least the case for the MATLAB version, I did not check if this is also correct for CVXPY